### PR TITLE
fix(date ipsos extractor)

### DIFF
--- a/scraping/scraping_IPSOS/ipsos_scraper/scraper.py
+++ b/scraping/scraping_IPSOS/ipsos_scraper/scraper.py
@@ -25,7 +25,6 @@ from .candidate_detector import check_if_candidate_data
 from .metadata_writer import write_metadata
 
 
-
 def scrape_ipsos_barometer(output_dir: str = "polls", dry_run: bool = False, force: bool = False) -> dict:
     """
     Scrape IPSOS Political Barometer for the latest poll data.
@@ -195,12 +194,15 @@ def scrape_ipsos_barometer(output_dir: str = "polls", dry_run: bool = False, for
                 # This can happen when IPSOS doesn't update their methodology section
                 if publication_date and survey_end_date:
                     from datetime import datetime as dt
+
                     pub_date = dt.strptime(publication_date, "%Y-%m-%d")
                     survey_date = dt.strptime(survey_end_date, "%Y-%m-%d")
                     # Survey should typically be in the same month or previous month
                     months_diff = (pub_date.year - survey_date.year) * 12 + (pub_date.month - survey_date.month)
                     if months_diff >= 1:
-                        print(f"\n   ⚠️  WARNING: Survey dates ({survey_end_date}) are {months_diff} months before publication ({publication_date})")
+                        print(
+                            f"\n   ⚠️  WARNING: Survey dates ({survey_end_date}) are {months_diff} months before publication ({publication_date})"
+                        )
                         print(f"   ⚠️  IPSOS may not have updated their methodology section - data may be stale!")
 
                 # Check each visualization to find candidate data


### PR DESCRIPTION

**Added** 
_get_filtered_soup_for_main_article()
 to filter out "Sur le même sujet" and "Articles liés" sections

**Fixed** 
extract_publication_date()  to use filtered soup and handle DD.MM.YY format
Added title-based date extraction as fallback
Consolidated duplicate code in _get_main_article_text()
Validation warning (ipsos_scraper/scraper.py):
Added warning when survey dates are ≥1 month before publication date to flag stale metadata
